### PR TITLE
chore(build): optimize vite config for production

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -38,17 +38,42 @@ for (const entry of readdirSync(__dirname, { withFileTypes: true })) {
 });
 
 export default defineConfig({
-    optimizeDeps: {
-        include: ['monaco-editor']
+    target: 'es2020',
+    css: {
+        devSourcemap: false
     },
     build: {
+        target: 'es2020',
+        cssCodeSplit: true,
+        minify: 'esbuild',
+        sourcemap: false,
+        reportCompressedSize: true,
+        chunkSizeWarningLimit: 800,
+        assetsInlineLimit: 4096,
         rollupOptions: {
             input,
             output: {
+                // Long-term caching: include content hash in the bundle file names
+                entryFileNames: 'assets/[name]-[hash].js',
+                chunkFileNames: 'assets/[name]-[hash].js',
+                assetFileNames: 'assets/[name]-[hash][extname]',
                 manualChunks: {
-                    'monaco-editor': ['monaco-editor']
+                    'monaco-editor': ['monaco-editor'],
+                    'mermaid-vendor': ['mermaid'],
+                    'katex-vendor': ['katex'],
+                    'markdown-vendor': ['marked', 'marked-katex-extension', 'marked-highlight', 'marked-gfm-heading-id', 'marked-footnote', 'marked-alert', 'markdownlint'],
+                    'dom-utils': ['dompurify', 'html2pdf.js', 'html2canvas', 'prismjs', 'github-markdown-css'],
+                    'storage-vendor': ['dexie']
                 }
             }
         }
+    },
+    esbuild: {
+        // Drop debugger statements in production
+        drop: ['debugger'],
+        legalComments: 'none'
+    },
+    optimizeDeps: {
+        include: ['monaco-editor']
     }
 });


### PR DESCRIPTION
## Summary
Production-only build configuration changes; no runtime behavior change.

- `target: 'es2020'` for both Vite and Rollup so the bundle ships modern JS to modern browsers (smaller payloads).
- Content-hashed entry/chunk/asset filenames (`assets/[name]-[hash].js`) for long-term browser caching.
- Six manual vendor chunks so the heaviest dependencies are split into cacheable, separately-loadable bundles:
  - `monaco-editor`
  - `mermaid-vendor`
  - `katex-vendor`
  - `markdown-vendor` (marked + 5 marked-* extensions + markdownlint)
  - `dom-utils` (DOMPurify, html2pdf.js, html2canvas, prismjs, github-markdown-css)
  - `storage-vendor` (dexie)
- Bumped `chunkSizeWarningLimit` to 800 KB to match the new chunk layout.
- `assetsInlineLimit: 4096`, `cssCodeSplit: true`, `minify: 'esbuild'`, `sourcemap: false`, `reportCompressedSize: true`.
- Dropped `debugger` statements and license comments from production via `esbuild.drop: ['debugger']` and `legalComments: 'none'`.
- Pre-bundled `monaco-editor` in dev via `optimizeDeps.include`.

## Test plan
- [ ] Run `npm run build` and confirm output `dist/assets/` contains the new hashed filenames
- [ ] Confirm the new vendor chunks appear (`monaco-editor-*.js`, `mermaid-vendor-*.js`, etc.)
- [ ] Confirm no `debugger` statements remain in any built JS (`grep -r 'debugger' dist/assets | wc -l` should be 0)
- [ ] Verify the dev server still works (`npm run dev`)
- [ ] Confirm bundle size budget: no individual chunk should exceed ~1 MB uncompressed
